### PR TITLE
Grove Guardian NW act description update

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -12750,7 +12750,7 @@
     "value": "Flying High"
   },
   "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardkillsilvergrovespecters": {
-    "desc": "Kill 3 Silver Grove Specters",
+    "desc": "Kill a Silver Grove Specter",
     "value": "Grove Guardian"
   },
   "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardkillthumper": {


### PR DESCRIPTION
Updated Grove Guardian NW act description (now requires only one specter to be defeated)

![20210612190244_1](https://user-images.githubusercontent.com/37784432/121793163-36902b80-cbb1-11eb-9abd-613bb193db17.jpg)

