### PR TITLE
fix: Kuva Survival Nightwave description

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -12776,7 +12776,7 @@
     "value": "Walk Without Rhythm"
   },
   "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardkuvasurvivalnocapsules": {
-    "desc": "Survive for over 30 minutes in Kuva Survival in the Kuva Fortress",
+    "desc": "Survive for over 30 minutes in Kuva Survival",
     "value": "Hold Your Breath"
   },
   "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardluapuzzles": {

--- a/data/languages.json
+++ b/data/languages.json
@@ -12776,7 +12776,7 @@
     "value": "Walk Without Rhythm"
   },
   "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardkuvasurvivalnocapsules": {
-    "desc": "Survive for over 30 minutes without using Life Support Modules in Kuva Survival",
+    "desc": "Survive for over 30 minutes in Kuva Survival in the Kuva Fortress",
     "value": "Hold Your Breath"
   },
   "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardluapuzzles": {


### PR DESCRIPTION
The "no life support" requirement was dropped from this challenge some time ago and the description updated to include "Kuva Fortress"

### Evidence/screenshot/link to line

Change to drop the "life support" requirement was announced here - https://forums.warframe.com/topic/1101014-nightwave-intermission/

Change to add the Kuva Fortress to description was announced here - https://forums.warframe.com/topic/1286070-update-3090-prime-resurgence/
