### PR TITLE
Add description for new acts.

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -12527,6 +12527,18 @@
     "desc": "Visit a Featured Dojo",
     "value": "Just Visiting"
   },
+  "/lotus/types/challenges/seasons/daily/seasondailyafirmshake": {
+    "desc": "Shake the hand of a fellow Tenno using the Handshake Emote",
+    "value": "A Firm Handshake"
+  },
+  "/lotus/types/challenges/seasons/daily/seasondailytwoforone": {
+    "desc": "Pierce and kill 2 or more enemies in a single Bow shot",
+    "value": "Two For One"
+  },
+  "/lotus/types/challenges/seasons/daily/seasondailybuilderstouch": {
+    "desc": "Builder's Touch",
+    "value": "Calim an item from your Foundry"
+  },
   "/lotus/types/challenges/seasons/weekly/seasonweeklyboardingpartynodamage": {
     "desc": "Clear a Railjack Boarding Party without your Warframe taking damage",
     "value": "Flawless"
@@ -12794,6 +12806,14 @@
   "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardunlockrelics": {
     "desc": "Unlock 10 Relics",
     "value": "Unlock Relics"
+  },
+  "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardantiquarian": {
+    "desc": "Open one of each era/tier of Relic (Lith, Meso, Neo, Axi)",
+    "value": "Antiquarian"
+  },
+  "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardterminated": {
+    "desc": "Destroy 3 Necramech vault guardians",
+    "value": "Terminated"
   },
   "/lotus/types/enemies/acolytes/areacasteracolyteagent": {
     "value": "Misery"


### PR DESCRIPTION
Add details for some of the new acts.


Daily:
* A Firm Shake
* Builder's Touch
* Two For One

Elite Weekly
* Antiquarian
* Terminated

### Evidence/screenshot/link to line

Wording taken from the in-games wording, with slight modification in the cases where a count is kept track of (Antiquarian, Terminated) to match other such cases.

![builders](https://user-images.githubusercontent.com/642056/162200482-5fa6961a-fb8f-4e80-84f6-932ce26e7625.png)
![firmshake](https://user-images.githubusercontent.com/642056/162200484-87ad9a9a-d4d9-4971-8ec3-a7d2dd0ec900.jpg)
![twoforone](https://user-images.githubusercontent.com/642056/162200491-2698f85b-cb6b-4d44-89a1-0470d6a5dbfe.png)

![antiquarian](https://user-images.githubusercontent.com/642056/162200463-9e0b337f-bd78-4270-bb24-ef5015098723.png)
![terminated](https://user-images.githubusercontent.com/642056/162200487-04fc210d-cfbe-42af-b23e-bf7006fa2cc9.png)

API strings taken from checiking the output at https://api.warframestat.us/pc