### PR TITLE
feat(nightwave): more new nightwave challenges

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -12539,6 +12539,14 @@
     "desc": "Builder's Touch",
     "value": "Calim an item from your Foundry"
   },
+  "/lotus/types/challenges/seasons/daily/seasondailydeathfromabove": {
+    "desc": "Death from Above",
+    "value": "Kill 10 enemies with ground slams"
+  },
+  "/lotus/types/challenges/seasons/daily/seasondailyaugmentation": {
+    "desc": "Augmentation",
+    "value": "Install an Augment Mod on your Warframe"
+  },
   "/lotus/types/challenges/seasons/weekly/seasonweeklyboardingpartynodamage": {
     "desc": "Clear a Railjack Boarding Party without your Warframe taking damage",
     "value": "Flawless"
@@ -12707,6 +12715,18 @@
     "desc": "Complete 5 different bounties in the Orb Vallis",
     "value": "Venus Bounty Hunter"
   },
+  "/lotus/types/challenges/seasons/weekly/seasonweeklynightandday": {
+    "desc": "Night and Day",
+    "value": "Collect 15 Vome or Fass Residue in the Cambion Drift"
+  },
+  "/lotus/types/challenges/seasons/weekly/seasonweeklyloyalty": {
+    "desc": "Loyalty",
+    "value": "Gain a total of 5,000 Standing across all Syndicate factions"
+  },
+  "/lotus/types/challenges/seasons/weekly/seasonweeklymadlab": {
+    "desc": "Mad Lab",
+    "value": "Plunder one of Alad V's secret laboratories on Jupiter"
+  },
   "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardcollectuniqueresources": {
     "desc": "Collect 20 different types of resources.",
     "value": "Resource Scavenger"
@@ -12814,6 +12834,10 @@
   "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardterminated": {
     "desc": "Destroy 3 Necramech vault guardians",
     "value": "Terminated"
+  },
+  "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardthepriceoffreedom": {
+    "desc": "The Price of Freedom",
+    "value": "Free one Captured Solaris using a Granum Crown"
   },
   "/lotus/types/enemies/acolytes/areacasteracolyteagent": {
     "value": "Misery"

--- a/data/languages.json
+++ b/data/languages.json
@@ -12547,6 +12547,10 @@
     "desc": "Augmentation",
     "value": "Install an Augment Mod on your Warframe"
   },
+  "/lotus/types/challenges/seasons/daily/seasondailytoppingoffthetank": {
+    "desc": "Topping Off the Tank",
+    "value": "Successfully defend an Excavator without allowing it to run out of power"
+  },
   "/lotus/types/challenges/seasons/weekly/seasonweeklyboardingpartynodamage": {
     "desc": "Clear a Railjack Boarding Party without your Warframe taking damage",
     "value": "Flawless"


### PR DESCRIPTION
Add several more of the new nightwave acts

Descriptions taken from in game, with minor modifications for those that keep a count (Death from Above, Loyalty, Night and Day)

API strings taken from checiking the output at https://api.warframestat.us/pc

Death from Above
![deathfromabove](https://user-images.githubusercontent.com/642056/166652828-fa026a53-4561-451c-8c80-aa27cbfb20e4.png)

Augmentation
![augemnt](https://user-images.githubusercontent.com/642056/166652818-28070744-9057-4159-ba5a-44375ebb89f3.png)

Topping of the Tank
![toppingodd](https://user-images.githubusercontent.com/642056/166652844-6640da5d-7691-4def-aa1d-e78017f0e384.jpg)

Night and Day
![nightandday](https://user-images.githubusercontent.com/642056/166652840-5ac26873-5511-44bd-8ddf-b9280dd4cb94.png)

Loyalty
![loyalty](https://user-images.githubusercontent.com/642056/166652833-08e446b6-f879-47c3-ac8b-5f71739029fa.png)

Mad Lab
![madlab](https://user-images.githubusercontent.com/642056/166652838-e39185f0-6ef1-4b6a-b309-77e0fb278f2b.png)

The Price of Freedom
![freedom](https://user-images.githubusercontent.com/642056/166652829-1edbe478-5f24-40b2-9c01-9ac096074d99.png)


I forgot to record the API string for Swatter, so that daily is not included.

