### PR TITLE
Fix number for the "Cold Steel" Nightwave task

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -12784,7 +12784,7 @@
     "value": "Kill Shot"
   },
   "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardkillenemiessteelpath": {
-    "desc": "Kill 100 Enemies on The Steel Path.",
+    "desc": "Kill 1,000 Enemies on The Steel Path.",
     "value": "Cold Steel"
   },
   "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardkilleximus": {


### PR DESCRIPTION
The cold steel task has the incorrect count

![coldsteel](https://user-images.githubusercontent.com/642056/168976887-b38df11b-965d-4673-afe7-3db8f76bcfb4.png)
