### PR TITLE
feat: discord community lang

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -698,6 +698,9 @@
   "/lotus/language/bosses/bosstylregor": {
     "value": "Boss Tyl Regor"
   },
+  "/lotus/language/communitymessages/joindiscord": {
+    "value": "Join the official Warframe Discord server"
+  },
   "/lotus/language/events/amalgameventname": {
     "value": "Operation: Hostile Mergers"
   },


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
I added the lang for the discord community title that shows up under news, might not really be important but thought I'd add it for completion sake. 

If I can figure it out I'll also add a way to parse it in the parser.

---

### Evidence/screenshot/link to line

```json
{
    "id": "62d31b87106360aa5703954d",
    "message": "/Lotus/Language/CommunityMessages/JoinDiscord",
    "link": "https://discord.com/invite/playwarframe",
    "imageLink": "https://i.imgur.com/CNrsc7V.png",
    "priority": false,
    "date": "2022-07-16T20:10:00.000Z",
    "eta": "65d 21h 55m 50s ago",
    "update": false,
    "primeAccess": false,
    "stream": false,
    "translations": {
      "en": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "fr": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "it": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "de": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "es": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "pt": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "ru": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "pl": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "uk": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "tr": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "ja": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "zh": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "ko": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "tc": "/Lotus/Language/CommunityMessages/JoinDiscord"
    },
    "asString": "[65d 21h 55m 50s ago] [/Lotus/Language/CommunityMessages/JoinDiscord](https://discord.com/invite/playwarframe)"
}
```

![Screenshot_20220920-141904.png](https://user-images.githubusercontent.com/6075693/191334887-f97c9e38-7fc9-4053-89de-40c2f22ef4ed.png)

### Considerations
- Does this contain a new dependency? **Yes**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**
