### PR TITLE
fix: new confiscated task nightwave daily

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -12595,6 +12595,10 @@
     "desc": "Kill 20 enemies using a Necramech while hovering",
     "value": "Stay on Top"
   },
+  "/lotus/types/challenges/seasons/daily/seasondailyhijackcrewship": {
+    "desc": "Hijack a Crewship from the enemy",
+    "value": "Confiscated"
+  },
   "/lotus/types/challenges/seasons/weekly/seasonweeklyboardingpartynodamage": {
     "desc": "Clear a Railjack Boarding Party without your Warframe taking damage",
     "value": "Flawless"


### PR DESCRIPTION
The Confiscated task is now a daily task, but otherwise the description and name is unchanged.

![confiscated](https://github.com/WFCD/warframe-worldstate-data/assets/642056/8f9d99a9-1004-40d8-92d1-4fc3a6bfdb0d)
