### PR TITLE
Add new nightwave act

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -12931,6 +12931,10 @@
      "desc": "Complete an Archon Hunt",
      "value": "Archon Hunter"
   },
+  "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardfriendsmirrordefense": {
+    "desc": "Complete 3 waves of Mirror Defense",
+    "value": "Crystal Clear"
+  },
   "/lotus/types/enemies/acolytes/areacasteracolyteagent": {
     "value": "Misery"
   },


### PR DESCRIPTION
### What did you fix?

Adds the new Nightwave Act "Crystal Clear"


### Evidence/screenshot/link to line

![Crystal_Clear](https://github.com/WFCD/warframe-worldstate-data/assets/642056/f8f6a6c7-cf9b-4228-ad45-faecbb2df775)
