### PR TITLE
Feature/update nw tasks

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -12764,7 +12764,7 @@
     "value": "Polarized"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklyvenusbounties": {
-    "desc": "Complete 5 different bounties in the Orb Vallis",
+    "desc": "Complete 3 different bounties in the Orb Vallis",
     "value": "Venus Bounty Hunter"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklynightandday": {

--- a/data/languages.json
+++ b/data/languages.json
@@ -12664,7 +12664,7 @@
     "value": "Operative"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklycompletesyndicatemissions": {
-    "desc": "Complete 10 Syndicate misions",
+    "desc": "Complete 5 Syndicate misions",
     "value": "Supporter"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklycompletetreasures": {

--- a/data/languages.json
+++ b/data/languages.json
@@ -12720,7 +12720,7 @@
     "value": "Earth Miner"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklyminerarevenusresources": {
-    "desc": "Mine 6 Rare Gems in the Orb Vallis",
+    "desc": "Mine 3 Rare Gems in the Orb Vallis",
     "value": "Venus Miner"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklyperfectanimalcapture": {

--- a/data/languages.json
+++ b/data/languages.json
@@ -12844,7 +12844,7 @@
     "value": "Profit-Taker"
   },
   "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardfriendssurvival": {
-    "desc": "Complete a Survival mission reaching at least 30 minutes",
+    "desc": "Complete a Survival mission reaching at least 20 minutes",
     "value": "Survival"
   },
   "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardindexwinstreak": {
@@ -12884,7 +12884,7 @@
     "value": "Walk Without Rhythm"
   },
   "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardkuvasurvivalnocapsules": {
-    "desc": "Survive for over 30 minutes in Kuva Survival",
+    "desc": "Survive for over 20 minutes in Kuva Survival",
     "value": "Hold Your Breath"
   },
   "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardluapuzzles": {

--- a/data/languages.json
+++ b/data/languages.json
@@ -12352,7 +12352,7 @@
     "value": "Relic Pack"
   },
   "/lotus/types/challenges/seasons/daily/seasondailyaimglide": {
-    "desc": "Kill 20 Enemies while Aim Gliding",
+    "desc": "Kill 15 Enemies while Aim Gliding",
     "value": "Glider"
   },
   "/lotus/types/challenges/seasons/daily/seasondailybulletjump": {

--- a/data/languages.json
+++ b/data/languages.json
@@ -12716,7 +12716,7 @@
     "value": "Tusk Thumpin"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklyminerareplainsresources": {
-    "desc": "Mine 6 Rare Gems in the Plains of Eidolon",
+    "desc": "Mine 3 Rare Gems in the Plains of Eidolon",
     "value": "Earth Miner"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklyminerarevenusresources": {

--- a/data/languages.json
+++ b/data/languages.json
@@ -12484,7 +12484,7 @@
     "value": "Hush"
   },
   "/lotus/types/challenges/seasons/daily/seasondailylichnode": {
-    "desc": "Clear a personal Lich Influenced Node",
+    "desc": "Clear a node influenced by a Kuva Lich or a Sister of Parvo",
     "value": "Reclaimed"
   },
   "/lotus/types/challenges/seasons/daily/seasondailymercykill": {

--- a/data/languages.json
+++ b/data/languages.json
@@ -12748,7 +12748,7 @@
     "value": "Test Subject"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklysimarisscan": {
-    "desc": "Complete 5 Scans for Cephalon Simaris",
+    "desc": "Complete 3 Scans for Cephalon Simaris",
     "value": "Sanctuary Researcher"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklyunlockdragonvaults": {

--- a/data/languages.json
+++ b/data/languages.json
@@ -12768,7 +12768,7 @@
     "value": "Venus Bounty Hunter"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklynightandday": {
-    "desc": "Collect 15 Vome or Fass Residue in the Cambion Drift",
+    "desc": "Collect 10 Vome or Fass Residue in the Cambion Drift",
     "value": "Night and Day"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklyloyalty": {


### PR DESCRIPTION
This updates a number of nightwave tasks that have recently changed in game

* Reclaimed - wording was updated to mention Sisters of Parvos
 ![NW_Kuva_Node](https://github.com/WFCD/warframe-worldstate-data/assets/642056/c21d85dc-0257-4660-a29a-b7c169925b26)
*  Glider - reduced to 15 enemies
![nw_aim_glide](https://github.com/WFCD/warframe-worldstate-data/assets/642056/d8114dec-2052-48f6-bcce-8362779da115)
* Earth Minter - chagned to 3 gems
![nw_Earth_Miner](https://github.com/WFCD/warframe-worldstate-data/assets/642056/d462212c-e103-421c-96fa-202472f03072)
* Venus Miner - changed to 3 gems
![nw_venus_miner](https://github.com/WFCD/warframe-worldstate-data/assets/642056/0d65cc0d-afdb-40ca-86d2-087b61a43605)
* Night and Day - reduced to 10 Fass and Vome
![nw_fass](https://github.com/WFCD/warframe-worldstate-data/assets/642056/7ecca417-87ac-4d88-9338-a51498dde9bb)
* Kuva Survial - reduced to 20 minutes 
![nw_kuva_survial](https://github.com/WFCD/warframe-worldstate-data/assets/642056/67eff5e9-d7ed-4755-9f1a-dda02a41b11a)
* Survial - reducedto 20 minutes 
![nw_survival](https://github.com/WFCD/warframe-worldstate-data/assets/642056/f5035273-a9a9-464e-a02f-8e40205c133c)
* Sanctuary Research - reduced to 3 scans
![nw_Researcher](https://github.com/WFCD/warframe-worldstate-data/assets/642056/52736011-209e-4f33-af32-894dac19a3e4)
* Supporter - Reduced to 5 misions
![NW_Syndicate](https://github.com/WFCD/warframe-worldstate-data/assets/642056/378d339b-3123-453a-abb4-d87737df986c)
* Venus Bounty Hunter - Reduced to 3 bounties
 ![nw_Venus_Bounty](https://github.com/WFCD/warframe-worldstate-data/assets/642056/e5a402cb-5b5a-45a6-97b4-72c9cf4ff670)
