### PR TITLE
fix: nightwave updates

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -12724,7 +12724,7 @@
     "value": "Venus Miner"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklyperfectanimalcapture": {
-    "desc": "Complete 6 different Perfect Animal Captures in Orb Vallis",
+    "desc": "Complete 3 different Perfect Animal Captures in Orb Vallis",
     "value": "Conservationist"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklypickupraremods": {

--- a/data/languages.json
+++ b/data/languages.json
@@ -12412,8 +12412,8 @@
     "value": "Warning Shot"
   },
   "/lotus/types/challenges/seasons/daily/seasondailykillenemieswhileonkdrive": {
-    "desc": "Kill 20 enemies while riding a K-Drive.",
-    "value": "Surf's Up!"
+    "desc": "Kill 20 enemies while riding a K-Drive, Kaithe, Velocipod or Merulina.",
+    "value": "Thrill Rider"
   },
   "/lotus/types/challenges/seasons/daily/seasondailykillenemieswithabilities": {
     "desc": "Kill 150 Enemies with Abilities",
@@ -12480,7 +12480,7 @@
     "value": "Go Viral"
   },
   "/lotus/types/challenges/seasons/daily/seasondailykillthrall": {
-    "desc": "Kill a Kuva Thrall",
+    "desc": "Kill a Kuva Thrall or Hound",
     "value": "Hush"
   },
   "/lotus/types/challenges/seasons/daily/seasondailylichnode": {

--- a/data/languages.json
+++ b/data/languages.json
@@ -12608,7 +12608,7 @@
     "value": "Earth Fisher"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklycatchrarevenusfish": {
-    "desc": "Catch 6 Rare Servofish in the Orb Vallis",
+    "desc": "Catch 3 Rare Servofish in the Orb Vallis",
     "value": "Venus Fisher"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklycompleteassassination": {

--- a/data/languages.json
+++ b/data/languages.json
@@ -12732,7 +12732,7 @@
     "value": "Enhance!"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklyplainsbounties": {
-    "desc": "Complete 5 different Bounties in the Plains of Eidolon",
+    "desc": "Complete 3 different Bounties in the Plains of Eidolon",
     "value": "Earth Bounty Hunter"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklyrailjackmissions": {


### PR DESCRIPTION
Further nightwave updates

- Thrill rider
   -  Task renamed
   - Description changed
![nw_thrill_rider](https://github.com/WFCD/warframe-worldstate-data/assets/642056/435cc82b-4bee-4717-ade3-7bacdf7063a9)
 
- Hush - description updated
![NW_Hush](https://github.com/WFCD/warframe-worldstate-data/assets/642056/c6b52220-b31e-408e-bd15-dc406ee58d1e)
- Orb Valis Conservation - number changed
![nw_orb_valis_capture](https://github.com/WFCD/warframe-worldstate-data/assets/642056/77f6b761-30ec-4911-956e-32973355a767)
- PoE bounties - number changed
![nw_poe_bounty](https://github.com/WFCD/warframe-worldstate-data/assets/642056/c475b463-ec75-4bf1-a239-fe92dc9736ee)
- Venus Fisher - number changed
![nw_venus_fisher](https://github.com/WFCD/warframe-worldstate-data/assets/642056/729cdfd4-214a-41cc-8a3c-43235fccea14)
