### PR TITLE
Update with some of the Vol 5 changes

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -12935,6 +12935,18 @@
     "desc": "Complete 3 waves of Mirror Defense",
     "value": "Crystal Clear"
   },
+  "/lotus/types/challenges/seasons/weekly/seasonweeklypermanentcompletemissions": {
+    "desc": "Kill 500 Enemies",
+    "value": "Not a Warning Shot"
+  },
+  "/lotus/types/challenges/seasons/weekly/seasonweeklypermanentkilleximus": {
+    "desc": "Kill 30 Eximus",
+    "value": "Eximus Eliminator"
+  },
+  "/lotus/types/challenges/seasons/weekly/seasonweeklypermanentkillenemies": {
+    "desc": "Complete any 15 missions",
+    "value": "Mission Complete"
+  },
   "/lotus/types/enemies/acolytes/areacasteracolyteagent": {
     "value": "Misery"
   },

--- a/data/languages.json
+++ b/data/languages.json
@@ -12672,7 +12672,7 @@
     "value": "Animator"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklycompletevenusrace": {
-    "desc": "Complete 3 different K-Drive races in Orb Vallis",
+    "desc": "Complete 3 different K-Drive races in Orb Vallis on Venus or in Cambion Drift on Deimos",
     "value": "Now Boarding"
   },
   "/lotus/types/challenges/seasons/weekly/seasonweeklydestroycrewshipartillery": {


### PR DESCRIPTION
* Add the 3 new permanent acts

![nw_eximus_eliminator](https://github.com/WFCD/warframe-worldstate-data/assets/642056/ef22fd8a-1ed4-4167-bdf7-44f9a48b6f9d)
![nw_kill_enemies](https://github.com/WFCD/warframe-worldstate-data/assets/642056/7e4141f1-8335-4118-a427-a82bca97d32b)
![nw_mision_complete](https://github.com/WFCD/warframe-worldstate-data/assets/642056/d2313e0f-a7bd-4e2d-9816-07f613ee51db)


* Update the wording for 'Now Boarding'

![nw_now_boarding](https://github.com/WFCD/warframe-worldstate-data/assets/642056/9a4903bb-01d8-4dd8-bf94-5e6fb6cc0ee1)
