### PR TITLE
feat: add new items from baro

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -18330,5 +18330,35 @@
   },
   "/Lotus/StoreItems/Upgrades/Skins/Sentinels/Masks/GaussSentinelMask": {
     "value": "Altra Sentinel Mask"
+  },
+  "/Lotus/StoreItems/Upgrades/Mods/Pistol/Expert/PrimedWeaponElectricityDamageMod": {
+    "value": "Primed Convulsion"
+  },
+  "/Lotus/StoreItems/Upgrades/Mods/Melee/WeaponGlaiveOnKillBuffSecondary": {
+    "value": "Combo Fury"
+  },
+  "/Lotus/StoreItems/Types/Items/ShipDecos/UmbraPedestal": {
+    "value": "Umbra Pedestal"
+  },
+  "/Lotus/StoreItems/Upgrades/Skins/Armor/TnShinaiArmor/TnShinaiArmorA": {
+    "value": "Tannukai Shoulder Plates"
+  },
+  "/Lotus/StoreItems/Upgrades/Skins/Armor/TnShinaiArmor/TnShinaiArmorC": {
+    "value": "Tannukai Chest Plates"
+  },
+  "/Lotus/StoreItems/Upgrades/Skins/Armor/TnShinaiArmor/TnShinaiArmorL": {
+    "value": "Tannukai Leg Plates"
+  },
+  "/Lotus/StoreItems/Upgrades/Skins/VoidTrader/AshLeverianLiosPistol": {
+    "value": "De Nas Pistol Skin"
+  },
+  "/Lotus/StoreItems/Upgrades/Skins/Operator/Hoods/HoodDuviriOperator": {
+    "value": "The Stranger's Hood (Operator)"
+  },
+  "/Lotus/StoreItems/Types/Game/QuartersWallpapers/LavosAlchemistWallpaper": {
+    "value": "Javi's Scrawling"
+  },
+  "/Lotus/StoreItems/Upgrades/Skins/Scarves/SolsticeBaroCape": {
+    "value": "Wintercress Syandana"
   }
 }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Adding mappings for Primed Convulsion, Combo Fury, Umbra Pedestal, Tannukai armor set, De Nas pistol skin. new Quarter's wallpaper javi's scrawling, and the wintercress Syandana.

---

### Evidence/screenshot/link to line

![Screenshot (29)](https://github.com/WFCD/warframe-worldstate-data/assets/6075693/98e8c7de-2a98-41de-bfbe-ffa29c893fa8)
![Screenshot (30)](https://github.com/WFCD/warframe-worldstate-data/assets/6075693/075d5fd2-8080-4481-b37d-d671c92f7f9d)
![Screenshot (31)](https://github.com/WFCD/warframe-worldstate-data/assets/6075693/e40edeb5-db8c-423f-8cbb-27b325639cca)



### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
