### PR TITLE
feat: add lang strings for Gyromag, Atmo, and Repeller Systems

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -18708,5 +18708,14 @@
   },
   "/Lotus/StoreItems/Upgrades/Skins/Scarves/SolsticeBaroCape": {
     "value": "Wintercress Syandana"
+  },
+  "/Lotus/Types/Gameplay/Venus/Resources/CorpusWidgetAItem": {
+    "value": "Gyromag Systems"
+  },
+  "/Lotus/Types/Gameplay/Venus/Resources/CorpusWidgetBItem": {
+    "value": "Atmo Systems"
+  },
+  "/Lotus/Types/Gameplay/Venus/Resources/CorpusWidgetCItem": {
+    "value": "Repeller Systems"
   }
 }


### PR DESCRIPTION
### What did you fix?
Add lang strings for Gyromag, Atmo, and Repeller Systems.

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

![SHARE_20240217_0546570](https://github.com/WFCD/warframe-worldstate-data/assets/6075693/4f0d8fa6-432a-41a8-8d71-0017bf6d7bbe)

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
