### PR TITLE
feat: add new Baro Ki'teer items

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -18717,5 +18717,26 @@
   },
   "/Lotus/Types/Gameplay/Venus/Resources/CorpusWidgetCItem": {
     "value": "Repeller Systems"
+  },
+  "/Lotus/StoreItems/Types/Items/ShipDecos/TarotCardTennoConI": {
+    "value": "Xaku Prex"
+  },
+  "/Lotus/StoreItems/Types/Items/ShipDecos/BekranZaftBucketBroom": {
+    "value": "Bekran Zaft's Equipment"
+  },
+  "/Lotus/StoreItems/Upgrades/Skins/Operator/BodySuits/BodySuitNovaEngineer": {
+    "value": "Masker's Theodolite Crewsuit"
+  },
+  "/Lotus/StoreItems/Upgrades/Skins/Operator/Hoods/HoodNovaEngineer": {
+    "value": "Masker's Theodolite Crewsuit Hood"
+  },
+  "/Lotus/StoreItems/Upgrades/Skins/Operator/Sleeves/SleevesNovaEngineer": {
+    "value": "Masker's Theodolite Crewsuit Sleeves"
+  },
+  "/Lotus/StoreItems/Upgrades/Skins/Operator/Leggings/LeggingsNovaEngineer": {
+    "value": "Masker's Theodolite Crewsuit Leggings"
+  },
+  "/Lotus/StoreItems/Upgrades/Skins/VoidTrader/ElixisNikana": {
+    "value": "Nikana Elixis Skin"
   }
 }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Adds new items from Baro

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

![Warframe_20240223185407](https://github.com/WFCD/warframe-worldstate-data/assets/6075693/dc3454cc-1f94-4712-8441-8098d34bce55)
![Warframe_20240223185444](https://github.com/WFCD/warframe-worldstate-data/assets/6075693/a5c31e11-54e8-4d7a-ad23-e73a115a429b)


### Considerations
- Does this contain a new dependency? **[Yes/No]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes/No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes/No]**
- Have I run the linter? **[Yes/No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix/Feature/Enhancement/Docs/Maintenance]**
