### PR TITLE
fix: add new lang for Teshin glyph

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -18738,5 +18738,8 @@
   },
   "/Lotus/StoreItems/Upgrades/Skins/VoidTrader/ElixisNikana": {
     "value": "Nikana Elixis Skin"
+  },
+  "/Lotus/StoreItems/Types/StoreItems/AvatarImages/AvatarImageTeshinVed": {
+    "value": "Teshin Glyph"
   }
 }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Add the uppercased version of "Teshin Glyph"

![image](https://github.com/WFCD/warframe-worldstate-data/assets/6075693/7b75f1a7-a159-4a3a-a695-3b4731e6b40e)


---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
