### PR TITLE
fix(langs): add `Rapier Tributaker Skin`

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -18741,5 +18741,8 @@
   },
   "/Lotus/StoreItems/Types/StoreItems/AvatarImages/AvatarImageTeshinVed": {
     "value": "Teshin Glyph"
+  },
+  "/Lotus/StoreItems/Upgrades/Skins/Weapons/Rapier/CrpRapierSkin": {
+    "value": "Rapier Tributaker Skin"
   }
 }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Adds Rapier Tributaker Skin lang string

![Screenshot (11)](https://github.com/WFCD/warframe-worldstate-data/assets/6075693/f43ad538-8c00-4a4d-8bdf-e60875e305ef)

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
