### PR TITLE
fix: add Umbra polarity to `translatePolarity`

### DIFF
--- a/tools/translation.js
+++ b/tools/translation.js
@@ -272,6 +272,7 @@ const polarityMap = {
   AP_TACTIC: 'Naramon',
   AP_POWER: 'Zenurik',
   AP_WARD: 'Unairu',
+  AP_UMBRA: 'Umbra',
 };
 
 /**


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Adds the umbra polarity to the polarity map

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
