### PR TITLE
fix: move postinstall to prepare

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "warframe-worldstate-data",
       "version": "1.0.5",
-      "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.2.1",

--- a/package.json
+++ b/package.json
@@ -48,10 +48,9 @@
   },
   "scripts": {
     "coverage": "npm test && c8 report --reporter=text-lcov | coveralls",
-    "postinstall": "npx install-peerdeps @wfcd/eslint-config@latest -S",
     "lint": "eslint --ignore-path .gitignore .",
     "lint:fix": "eslint --ignore-path .gitignore . --fix",
-    "prepare": "husky",
+    "prepare": "husky && npx install-peerdeps @wfcd/eslint-config@latest -S",
     "sort": "node tools/sort_languages.py",
     "test": "c8 mocha",
     "validate": "npm run lint:fix && npm run test && git add -u ."


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
prepare instead of postinstall peer deps

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Maintenance]**
