### PR TITLE
feat: add new Omnia fissures

### DIFF
--- a/data/fissureModifiers.json
+++ b/data/fissureModifiers.json
@@ -18,5 +18,9 @@
   "VoidT5": {
     "value": "Requiem",
     "num": 5
+  },
+  "VoidT6": {
+    "value": "Omnia",
+    "num": 6
   }
 }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Adds new Omnia T6 fissures

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line


![20240327182442_1](https://github.com/WFCD/warframe-worldstate-data/assets/6075693/5a0dbbe8-c4df-4a1d-9d7b-efdb4c6460f8)


### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **YesNo**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Feature**
