### PR TITLE
fix: add missing Lua nodes

### DIFF
--- a/data/solNodes.json
+++ b/data/solNodes.json
@@ -1469,6 +1469,11 @@
     "enemy": "Orokin",
     "type": "Survival"
   },
+  "SolNode310": {
+    "value": "Circulus (Lua)",
+    "enemy": "Grineer",
+    "type": "Survival"
+  },
   "SettlementNode1": {
     "value": "Roche (Phobos)",
     "enemy": "Corpus",

--- a/data/solNodes.json
+++ b/data/solNodes.json
@@ -1467,7 +1467,7 @@
   "SolNode309": {
     "value": "Yuvarium (Lua)",
     "enemy": "Orokin",
-    "type": "Conjunction Survival"
+    "type": "Survival"
   },
   "SettlementNode1": {
     "value": "Roche (Phobos)",

--- a/data/solNodes.json
+++ b/data/solNodes.json
@@ -1464,6 +1464,11 @@
     "enemy": "Corpus",
     "type": "Disruption"
   },
+  "SolNode309": {
+    "value": "Yuvarium (Lua)",
+    "enemy": "Orokin",
+    "type": "Conjunction Survival"
+  },
   "SettlementNode1": {
     "value": "Roche (Phobos)",
     "enemy": "Corpus",


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Adds Yuvarium and Circulus Lua to SolNodes

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

![18e84e3a06a70-screenshotUrl](https://github.com/WFCD/warframe-worldstate-data/assets/6075693/501b60e3-7802-4d2d-80ee-6b9799858eb1)
![SHARE_20240328_0722530](https://github.com/WFCD/warframe-worldstate-data/assets/6075693/49ae37f1-fdf6-49b5-a8cd-5592bd7dddd2)

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
