### PR TITLE
fix: typo in Vazarin focus/polarity

### DIFF
--- a/tools/translation.js
+++ b/tools/translation.js
@@ -280,7 +280,7 @@ const valMapping = (key, map) => {
 
 const focusMap = {
   'Focus/Attack': 'Madurai',
-  'Focus/Defense': 'Varazin',
+  'Focus/Defense': 'Vazarin',
   'Focus/Tactic': 'Naramon',
   'Focus/Power': 'Zenurik',
   'Focus/Ward': 'Unairu',
@@ -294,7 +294,7 @@ export const translateFocus = (focus = '') => valMapping(focus, focusMap);
 
 const polarityMap = {
   AP_ATTACK: 'Madurai',
-  AP_DEFENSE: 'Varazin',
+  AP_DEFENSE: 'Vazarin',
   AP_TACTIC: 'Naramon',
   AP_POWER: 'Zenurik',
   AP_WARD: 'Unairu',


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
A typo found in polarityMap and focusMap where `Vazarin` is typed out as `Varazin`

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line
https://github.com/WFCD/warframe-worldstate-data/blob/master/tools%2Ftranslation.js#L283
https://github.com/WFCD/warframe-worldstate-data/blob/master/tools%2Ftranslation.js#L297

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
