### PR TITLE
fix: two archon shards using `upgrades` instead of the `upgradeTypes` key

### DIFF
--- a/data/archonShards.json
+++ b/data/archonShards.json
@@ -21,7 +21,7 @@
     },
     "ACC_RED": {
         "value": "Crimson",
-        "upgrades": {
+        "upgradeTypes": {
             "/Lotus/Upgrades/Invigorations/ArchonCrystalUpgrades/ArchonCrystalUpgradeMeleeCritDamage": {
                 "value": "+25% Melee Critical Damage"
             },
@@ -132,7 +132,7 @@
     },
     "ACC_RED_MYTHIC": {
         "value": "Tauforged Crimson",
-        "upgrades": {
+        "upgradeTypes": {
             "/Lotus/Upgrades/Invigorations/ArchonCrystalUpgrades/ArchonCrystalUpgradeMeleeCritDamageMythic": {
                 "value": "+37.5% Melee Critical Damage"
             },


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Didn't realize I left the crimson shards with `upgrades` when I switched it over to `upgradeTypes`

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
