### PR TITLE
fix: add `Armatus (Deimos)`

### DIFF
--- a/data/solNodes.json
+++ b/data/solNodes.json
@@ -1339,6 +1339,11 @@
     "enemy": "The Murmur",
     "type": "Netracells"
   },
+  "SolNode721": {
+    "value": "Armatus (Deimos)",
+    "enemy": "The Murmur",
+    "type": "Disruption"
+  },
   "SolNode740": {
     "value": "The Ropalolyst (Jupiter)",
     "enemy": "Sentient",


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Adds https://warframe.fandom.com/wiki/Armatus to solNodes

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
