### PR TITLE
feat: add lang for `Primed Redirection`

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -18744,5 +18744,8 @@
   },
   "/Lotus/StoreItems/Upgrades/Skins/Weapons/Rapier/CrpRapierSkin": {
     "value": "Rapier Tributaker Skin"
+  },
+  "/Lotus/StoreItems/Upgrades/Mods/Warframe/Expert/AvatarShieldMaxModExpert": {
+    "value": "Primed Redirection"
   }
 }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
adds lang for `Primed Redirection` and closes https://github.com/WFCD/warframe-worldstate-parser/issues/538

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Feature**
