### PR TITLE
fix: add `ScoreLocTag` for `Thermia Fracture` event

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -758,6 +758,9 @@
   "/lotus/language/g1quests/heatfissureseventname": {
     "value": "Thermia Fractures"
   },
+  "/Lotus/Language/G1Quests/HeatFissuresEventScore": {
+    "valu": "Thermia Fractures Sealed"
+  },
   "/lotus/language/g1quests/kelaeventbonustitle": {
     "value": "Endless Rathuum"
   },

--- a/data/languages.json
+++ b/data/languages.json
@@ -759,7 +759,7 @@
     "value": "Thermia Fractures"
   },
   "/Lotus/Language/G1Quests/HeatFissuresEventScore": {
-    "valu": "Thermia Fractures Sealed"
+    "value": "Thermia Fractures Sealed"
   },
   "/lotus/language/g1quests/kelaeventbonustitle": {
     "value": "Endless Rathuum"


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Add event progress string for Thermia fracture 

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
