### PR TITLE
feat: more deep archimedea modifiers

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -18837,5 +18837,13 @@
   },
   "/Lotus/StoreItems/Types/Items/ShipDecos/Plushies/Plushy2021QTCC": {
     "value": "Conquera Kuaka Floof"
+  },
+  "GrowingIncursion": {
+    "value": "Fissure Cascade",
+    "desc": "Fissures rip into the mission, causing the Enemy Level to go up by 1 every 10s. Destroy them to stop the level from increasing further."
+  },
+  "RegeneratingEnemies": {
+    "value": "Hostile Regeneration",
+    "desc": "Enemy health slowly regenerates."
   }
 }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
adds Hostile Regeneration and Fissure Cascade modifiers 

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**
