### PR TITLE
feat: add 1999 calendar langs

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -18872,7 +18872,7 @@
     "desc": "Increase energy restoration by 2/s."
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesEasy": {
-    "value": "PUNISH SCALDRA",
+    "value": "Punish Sscaldra",
     "desc": "Kill 250 Scaldra Troops"
   },
   "/Lotus/StoreItems/Types/BoosterPacks/CalendarMajorArtifactPack": {
@@ -18888,11 +18888,11 @@
     "value": "2000 x Kuva"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillEnemiesWithAbilitiesMedium": {
-    "value": "DEMONSTRATION OF POWER",
+    "value": "Demonstration of power",
     "desc": "Kill 300 Enemies with Abilities"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesWithMeleeMedium": {
-    "value": "MAKE IT PERSONAL",
+    "value": "Make it personal",
     "desc": "Kill 300 Scaldra Troops with Melee Weapons"
   },
   "/Lotus/Upgrades/Calendar/CompanionsBuffNearbyPlayer": {
@@ -18911,7 +18911,7 @@
     "value": "Arcane Enhancements"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillTechrotEnemiesHard": {
-    "value": "PURGE THE INFECTION",
+    "value": "Purge the infection",
     "desc": "Kill 1,000 Techrot"
   },
   "/Lotus/StoreItems/Types/Items/MiscItems/WeaponSecondaryArcaneUnlocker": {
@@ -18921,7 +18921,7 @@
     "value": "6,000 Endo"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarDestroyPropsMedium": {
-    "value": "STARVE THE BEAST",
+    "value": "Starve the beast",
     "desc": "Destroy 150 Containers"
   },
   "/Lotus/StoreItems/Types/Items/MiscItems/WeaponUtilityUnlocker": {

--- a/data/languages.json
+++ b/data/languages.json
@@ -18854,5 +18854,89 @@
   },
   "/Lotus/Types/Gameplay/NarmerSorties/ArchonCrystalAmarMythic": {
     "value": "Tauforged Crimson Archon Shard"
+  },
+  "/Lotus/Types/Challenges/Calendar1999/CalendarKillEximusEasy": {
+    "value": "EX-EXIMUS",
+    "desc": "Kill 10 Eximus"
+  },
+  "/Lotus/Upgrades/Calendar/MagazineCapacity": {
+    "value": "Heavy Mags",
+    "desc": "Increase magazine capacity by 25%"
+  },
+  "/Lotus/Upgrades/Calendar/Armor": {
+    "value": "Thick Skin",
+    "desc": "Gain +250 Armor."
+  },
+  "/Lotus/Upgrades/Calendar/EnergyRestoration": {
+    "value": "Espresso Shots",
+    "desc": "Increase energy restoration by 2/s."
+  },
+  "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesEasy": {
+    "value": "PUNSIH SCALDRA",
+    "desc": "Kill 250 Scaldra Troops"
+  },
+  "/Lotus/StoreItems/Types/BoosterPacks/CalendarMajorArtifactPack": {
+    "value": "Arcane Enhancements: Double Pack"
+  },
+  "/Lotus/StoreItems/Types/Gameplay/NarmerSorties/ArchonCrystalGreen": {
+    "value": "Emerald Archon Shard"
+  },
+  "/Lotus/StoreItems/Types/Recipes/Components/WeaponUtilityUnlockerBlueprint": {
+    "value": "Exilus Weapon Adapter Blueprint"
+  },
+  "/Lotus/Types/StoreItems/Packages/Calendar/CalendarKuvaBundleSmall": {
+    "value": "2000 x Kuva"
+  },
+  "/Lotus/Types/Challenges/Calendar1999/CalendarKillEnemiesWithAbilitiesMedium": {
+    "value": "DEMONSTRATION OF POWER",
+    "desc": "Kill 300 Enemies with Abilities"
+  },
+  "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesWithMeleeMedium": {
+    "value": "MAKE IT PERSONAL",
+    "desc": "Kill 300 Scaldra Troops with Melee Weapons"
+  },
+  "/Lotus/Upgrades/Calendar/CompanionsBuffNearbyPlayer": {
+    "value": "More the Merrier",
+    "desc": "Non-Tenno Allies within 20m all gain +5% Melee Attack Speed and +20% Fire Rate for each one in range."
+  },
+  "/Lotus/Upgrades/Calendar/OrbsDuplicateOnPickup": {
+    "value": "Targeted Medicine",
+    "desc": "Shoot Health Orbs to pick them up. Health orbs now have 25% chance to duplicate when picked up."
+  },
+  "/Lotus/Upgrades/Calendar/FinisherChancePerComboMultiplier": {
+    "value": "Combo Killer",
+    "desc": "Combo Multiplier increases the chance of enemies being susceptible to finishers after a melee hit. 5% per Multiplier Max 65% with Venka Prime."
+  },
+  "/Lotus/StoreItems/Types/BoosterPacks/CalendarArtifactPack": {
+    "value": "Arcane Enhancements"
+  },
+  "/Lotus/Types/Challenges/Calendar1999/CalendarKillTechrotEnemiesHard": {
+    "value": "PURGE THE INFECTION",
+    "desc": "Kill 1,000 Techrot"
+  },
+  "/Lotus/StoreItems/Types/Items/MiscItems/WeaponSecondaryArcaneUnlocker": {
+    "value": "Secondary Arcane Adapter"
+  },
+  "/Lotus/StoreItems/Upgrades/Mods/FusionBundles/CircuitSilverSteelPathFusionBundle": {
+    "value": "6,000 Endo"
+  },
+  "/Lotus/Types/Challenges/Calendar1999/CalendarDestroyPropsMedium": {
+    "value": "STARVE THE BEAST",
+    "desc": "Destroy 150 Containers"
+  },
+  "/Lotus/StoreItems/Types/Items/MiscItems/WeaponUtilityUnlocker": {
+    "value": "Exilus Weapon Adapter"
+  },
+  "/Lotus/Upgrades/Calendar/EnergyOrbToAbilityRange": {
+    "value": "Broadened Horizons",
+    "desc": "On Energy Pickup increase ability range by 10% for 10s."
+  },
+  "/Lotus/Upgrades/Calendar/MeleeAttackSpeed": {
+    "value": "No Quater",
+    "desc": "+25% Melee Attack Speed."
+  },
+  "/Lotus/Upgrades/Calendar/CompanionDamage": {
+    "value": "Got Your Back",
+    "desc": "Specters and companions gain +250% damage."
   }
 }

--- a/data/languages.json
+++ b/data/languages.json
@@ -18872,7 +18872,7 @@
     "desc": "Increase energy restoration by 2/s."
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesEasy": {
-    "value": "Punish Sscaldra",
+    "value": "Punish Scaldra",
     "desc": "Kill 250 Scaldra Troops"
   },
   "/Lotus/StoreItems/Types/BoosterPacks/CalendarMajorArtifactPack": {

--- a/data/languages.json
+++ b/data/languages.json
@@ -18872,7 +18872,7 @@
     "desc": "Increase energy restoration by 2/s."
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesEasy": {
-    "value": "PUNSIH SCALDRA",
+    "value": "PUNISH SCALDRA",
     "desc": "Kill 250 Scaldra Troops"
   },
   "/Lotus/StoreItems/Types/BoosterPacks/CalendarMajorArtifactPack": {
@@ -18932,7 +18932,7 @@
     "desc": "On Energy Pickup increase ability range by 10% for 10s."
   },
   "/Lotus/Upgrades/Calendar/MeleeAttackSpeed": {
-    "value": "No Quater",
+    "value": "No Quarter",
     "desc": "+25% Melee Attack Speed."
   },
   "/Lotus/Upgrades/Calendar/CompanionDamage": {

--- a/test/utilities/translation.spec.js
+++ b/test/utilities/translation.spec.js
@@ -24,8 +24,10 @@ import {
   sortieModifier,
   syndicate,
   toTitleCase,
+  translateCalendarEvent,
   translateFocus,
   translatePolarity,
+  translateSeason,
   upgrade,
 } from '../../tools/translation.js';
 
@@ -278,6 +280,20 @@ describe('translation', () => {
       });
       it("should return the key if it's not found in the data", () => {
         archonShardUpgradeType('notfound', 'notfound').should.equal('notfound');
+      });
+    });
+    describe('translateCalendarEvent()', () => {
+      it('should return a translation of the key', () => {
+        translateCalendarEvent('CET_CHALLENGE').should.equal('To Do');
+      });
+      it("should return the key if it's not found in the data", () => {
+        translateCalendarEvent('None').should.equal('None');
+      });
+    });
+    describe('translateSeason()', () => {
+      it('should return a readable version of a season string', () => {
+        translateSeason('CST_WINTER').should.equal('Winter');
+        translateSeason('None').should.equal('None');
       });
     });
   });

--- a/tools/translation.js
+++ b/tools/translation.js
@@ -309,6 +309,27 @@ const polarityMap = {
  */
 export const translatePolarity = (pol = '') => valMapping(pol, polarityMap);
 
+const eventTypeMap = {
+  CET_CHALLENGE: 'To Do',
+  CET_UPGRADE: 'Override',
+  CET_REWARD: 'Big Prize!',
+  CET_PLOT: 'Birthday',
+};
+
+/**
+ * Translate the given event key
+ * @param {string} key Unique event type
+ * @returns {string}
+ */
+export const translateCalendarEvent = (key) => valMapping(key, eventTypeMap);
+
+/**
+ * Translate the given season name to a non-unique string
+ * @param {string} season Unique season name
+ * @returns {string}
+ */
+export const translateSeason = (season) => toTitleCase(season.replace('CST_', ''));
+
 /**
  * An object containing functions to convert in-game names to their localizations
  * @typedef {Record<string, function>} Translator
@@ -338,6 +359,8 @@ export const translatePolarity = (pol = '') => valMapping(pol, polarityMap);
  * @property {function} archonShard      - Converts archon shard names
  * @property {function} archonShardColor - Converts archon shard names to in-game color values
  * @property {function} archonShardUpgradeType - Convert archon shard upgrade type
+ * @property {function} translateCalendarEvent - Translate the given event key
+ * @property {function} translateSeason - Translate the given season name to a non-unique string
  */
 export default {
   faction,
@@ -368,4 +391,6 @@ export default {
   archonShard,
   archonShardColor,
   archonShardUpgradeType,
+  translateCalendarEvent,
+  translateSeason,
 };


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Adds language and translation functions for 1999 Calendar data

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Feature**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced two new translation functions for calendar events and season names, enhancing localization capabilities.

- **Tests**
	- Added test cases to verify the functionality and default behavior of the new translation functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->