### PR TITLE
feat: add language strings for more calendar challenges, rewards, and overrides

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -296,7 +296,7 @@
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillEnemiesWithAbilitiesHard": {
     "value": "Demonstration of power",
-    "description": "Kill 500 Enemies with Abilities"
+    "desc": "Kill 500 Enemies with Abilities"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillEnemiesWithAbilitiesMedium": {
     "value": "Demonstration of power",
@@ -308,7 +308,7 @@
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillEximusHard": {
     "value": "EX-EXIMUS",
-    "description": "Kill 30 Eximus"
+    "desc": "Kill 30 Eximus"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesEasy": {
     "value": "Punish Scaldra",
@@ -316,11 +316,11 @@
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesMedium": {
     "value": "Punish Scaldra",
-    "description": "Kill 350 Scaldra Troops"
+    "desc": "Kill 350 Scaldra Troops"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesWithAbilitiesEasy": {
     "value": "Shock and Awe",
-    "description": "Kill 75 Scaldra Troops with Abilities"
+    "desc": "Kill 75 Scaldra Troops with Abilities"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesWithMeleeMedium": {
     "value": "Make it personal",
@@ -328,7 +328,7 @@
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillTechrotEnemiesEasy": {
     "value": "Purge the infection",
-    "description": "Kill 250 Techrot"
+    "desc": "Kill 250 Techrot"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillTechrotEnemiesHard": {
     "value": "Purge the infection",
@@ -336,7 +336,7 @@
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillTechrotEnemiesWithMeleeMedium": {
     "value": "Electronic waste Disposal",
-    "description": "Kill 200 Techrot with Melee Weapons"
+    "desc": "Kill 200 Techrot with Melee Weapons"
   },
   "/Lotus/Types/Gameplay/JadeShadows/Resources/AscensionEventResourceItem": {
     "value": "Volatile Motes"
@@ -409,7 +409,7 @@
   },
   "/Lotus/Upgrades/Calendar/AbilityStrength": {
     "value": "Power Gains",
-    "description": "Increase Ability Strength +25%.\n+25% Ability Strength"
+    "desc": "Increase Ability Strength +25%.\n+25% Ability Strength"
   },
   "/Lotus/Upgrades/Calendar/Armor": {
     "value": "Thick Skin",
@@ -437,11 +437,11 @@
   },
   "/Lotus/Upgrades/Calendar/GasChanceToPrimaryAndSecondary": {
     "value": "Toxic Shot",
-    "description": "Add 25% Gas Status Chance to Primary and Secondary weapons."
+    "desc": "Add 25% Gas Status Chance to Primary and Secondary weapons."
   },
   "/Lotus/Upgrades/Calendar/HealingEffects": {
     "value": "Emergency Medicine",
-    "description": "All restoration effects provided by Orb pickups increased by 25%."
+    "desc": "All restoration effects provided by Orb pickups increased by 25%."
   },
   "/Lotus/Upgrades/Calendar/MagazineCapacity": {
     "value": "Heavy Mags",
@@ -453,7 +453,7 @@
   },
   "/Lotus/Upgrades/Calendar/MeleeCritChance": {
     "value": "Practiced Precision",
-    "description": "+20% Melee Critical Chance (x2 for Heavy Attacks)."
+    "desc": "+20% Melee Critical Chance (x2 for Heavy Attacks)."
   },
   "/Lotus/Upgrades/Calendar/OrbsDuplicateOnPickup": {
     "value": "Targeted Medicine",
@@ -461,7 +461,7 @@
   },
   "/Lotus/Upgrades/Calendar/RefundBulletOnStatusProc": {
     "value": "Free Shot",
-    "description": "Triggering a status proc has a 10% chance to reload the triggering bullet into the clip."
+    "desc": "Triggering a status proc has a 10% chance to reload the triggering bullet into the clip."
   },
   "/Lotus/Upgrades/Skins/Armor/SWPiercingEyeShoulderArmor/SWPiercingEyeShoulderArmor": {
     "value": "Piercing Eye Shoulder Armor"

--- a/data/languages.json
+++ b/data/languages.json
@@ -26,6 +26,9 @@
   "/Lotus/StoreItems/Types/BoosterPacks/CalendarMajorArtifactPack": {
     "value": "Arcane Enhancements: Double Pack"
   },
+  "/Lotus/StoreItems/Types/BoosterPacks/CalendarRivenPack": {
+    "value": "Riven"
+  },
   "/Lotus/StoreItems/Types/Game/ActionFigureDioramas/EmpyreanRegionADiorama": {
     "value": "Empyrean Vignette"
   },
@@ -37,6 +40,9 @@
   },
   "/Lotus/StoreItems/Types/Game/QuartersWallpapers/LavosAlchemistWallpaper": {
     "value": "Javi's Scrawling"
+  },
+  "/Lotus/StoreItems/Types/Gameplay/NarmerSorties/ArchonCrystalAmar": {
+    "value": "Crimson Archon Shard"
   },
   "/Lotus/StoreItems/Types/Gameplay/NarmerSorties/ArchonCrystalGreen": {
     "value": "Emerald Archon Shard"
@@ -288,6 +294,10 @@
     "value": "Starve the beast",
     "desc": "Destroy 150 Containers"
   },
+  "/Lotus/Types/Challenges/Calendar1999/CalendarKillEnemiesWithAbilitiesHard": {
+    "value": "Demonstration of power",
+    "description": "Kill 500 Enemies with Abilities"
+  },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillEnemiesWithAbilitiesMedium": {
     "value": "Demonstration of power",
     "desc": "Kill 300 Enemies with Abilities"
@@ -296,17 +306,37 @@
     "value": "EX-EXIMUS",
     "desc": "Kill 10 Eximus"
   },
+  "/Lotus/Types/Challenges/Calendar1999/CalendarKillEximusHard": {
+    "value": "EX-EXIMUS",
+    "description": "Kill 30 Eximus"
+  },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesEasy": {
     "value": "Punish Scaldra",
     "desc": "Kill 250 Scaldra Troops"
+  },
+  "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesMedium": {
+    "value": "Punish Scaldra",
+    "description": "Kill 350 Scaldra Troops"
+  },
+  "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesWithAbilitiesEasy": {
+    "value": "Shock and Awe",
+    "description": "Kill 75 Scaldra Troops with Abilities"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesWithMeleeMedium": {
     "value": "Make it personal",
     "desc": "Kill 300 Scaldra Troops with Melee Weapons"
   },
+  "/Lotus/Types/Challenges/Calendar1999/CalendarKillTechrotEnemiesEasy": {
+    "value": "Purge the infection",
+    "description": "Kill 250 Techrot"
+  },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillTechrotEnemiesHard": {
     "value": "Purge the infection",
     "desc": "Kill 1,000 Techrot"
+  },
+  "/Lotus/Types/Challenges/Calendar1999/CalendarKillTechrotEnemiesWithMeleeMedium": {
+    "value": "Electronic waste Disposal",
+    "description": "Kill 200 Techrot with Melee Weapons"
   },
   "/Lotus/Types/Gameplay/JadeShadows/Resources/AscensionEventResourceItem": {
     "value": "Volatile Motes"
@@ -337,6 +367,9 @@
   },
   "/Lotus/Types/StoreItems/Packages/AOTZSupporterPackB": {
     "value": "Chrysalith Pack"
+  },
+  "/Lotus/Types/StoreItems/Packages/Calendar/CalendarKuvaBundleLarge": {
+    "value": "6000 x Kuva"
   },
   "/Lotus/Types/StoreItems/Packages/Calendar/CalendarKuvaBundleSmall": {
     "value": "2000 x Kuva"
@@ -374,6 +407,10 @@
   "/Lotus/Types/StoreItems/Packages/VeilbreakerVoidshellBundle": {
     "value": "Void Adornment Bundle II"
   },
+  "/Lotus/Upgrades/Calendar/AbilityStrength": {
+    "value": "Power Gains",
+    "description": "Increase Ability Strength +25%.\n+25% Ability Strength"
+  },
   "/Lotus/Upgrades/Calendar/Armor": {
     "value": "Thick Skin",
     "desc": "Gain +250 Armor."
@@ -398,6 +435,14 @@
     "value": "Combo Killer",
     "desc": "Combo Multiplier increases the chance of enemies being susceptible to finishers after a melee hit. 5% per Multiplier Max 65% with Venka Prime."
   },
+  "/Lotus/Upgrades/Calendar/GasChanceToPrimaryAndSecondary": {
+    "value": "Toxic Shot",
+    "description": "Add 25% Gas Status Chance to Primary and Secondary weapons."
+  },
+  "/Lotus/Upgrades/Calendar/HealingEffects": {
+    "value": "Emergency Medicine",
+    "description": "All restoration effects provided by Orb pickups increased by 25%."
+  },
   "/Lotus/Upgrades/Calendar/MagazineCapacity": {
     "value": "Heavy Mags",
     "desc": "Increase magazine capacity by 25%"
@@ -406,9 +451,17 @@
     "value": "No Quarter",
     "desc": "+25% Melee Attack Speed."
   },
+  "/Lotus/Upgrades/Calendar/MeleeCritChance": {
+    "value": "Practiced Precision",
+    "description": "+20% Melee Critical Chance (x2 for Heavy Attacks)."
+  },
   "/Lotus/Upgrades/Calendar/OrbsDuplicateOnPickup": {
     "value": "Targeted Medicine",
     "desc": "Shoot Health Orbs to pick them up. Health orbs now have 25% chance to duplicate when picked up."
+  },
+  "/Lotus/Upgrades/Calendar/RefundBulletOnStatusProc": {
+    "value": "Free Shot",
+    "description": "Triggering a status proc has a 10% chance to reload the triggering bullet into the clip."
   },
   "/Lotus/Upgrades/Skins/Armor/SWPiercingEyeShoulderArmor/SWPiercingEyeShoulderArmor": {
     "value": "Piercing Eye Shoulder Armor"


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Add more language strings for 1999 calendar

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded in-game store with new item packs such as a special bonus pack and a large resource bundle.
  - Added a series of gameplay challenges that test players with specific enemy defeat counts and ability-based tasks.
  - Introduced new upgrades enhancing various game mechanics, including ability strength, weapon status chance, restoration effects, melee critical chance, and a bonus chance for reloading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->