### PR TITLE
feat: add "The Hex" syndicate data

### DIFF
--- a/data/syndicatesData.json
+++ b/data/syndicatesData.json
@@ -79,5 +79,8 @@
   },
   "EntratiLabSyndicate": {
     "name": "Cavia"
+  },
+  "HexSyndicate": {
+    "name": "The Hex"
   }
 }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
add hex syndicate name

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new syndicate entry named "The Hex" to the syndicate listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->