### PR TITLE
fix: add more calendar challenges, overrides, and baro items

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -394,7 +394,7 @@
     "desc": "Kill 500 Techrot"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillTechrotEnemiesWithAbilitiesMedium": {
-    "values": "Null and Void",
+    "value": "Null and Void",
     "desc": "Kill 200 Techrot with Abilities"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillTechrotEnemiesWithMeleeMedium": {

--- a/data/languages.json
+++ b/data/languages.json
@@ -68,6 +68,9 @@
   "/Lotus/StoreItems/Types/Items/ShipDecos/DomsFinalDrink": {
     "value": "Aged Claret of Denas"
   },
+  "/Lotus/StoreItems/Types/Items/ShipDecos/ErraBobbleHead": {
+    "value": "Noggle Statue - Erra"
+  },
   "/Lotus/StoreItems/Types/Items/ShipDecos/GarvLatroxPoster": {
     "value": "Garv & Latrox Poster"
   },
@@ -83,6 +86,9 @@
   "/Lotus/StoreItems/Types/Items/ShipDecos/LisetPropCorpusBasilisk": {
     "value": "Basilisk Fighter Decoration"
   },
+  "/Lotus/StoreItems/Types/Items/ShipDecos/LisetPropGrineerCutter": {
+    "value": "Cutter Fighter Decoration"
+  },
   "/Lotus/StoreItems/Types/Items/ShipDecos/LisetPropGrineerFlak": {
     "value": "Flak Fighter Decoration"
   },
@@ -94,6 +100,9 @@
   },
   "/Lotus/StoreItems/Types/Items/ShipDecos/SummerGameFestPoster": {
     "value": "Dog Days Protea Display"
+  },
+  "/Lotus/StoreItems/Types/Items/ShipDecos/TarotCardTennoConA": {
+    "value": "Deimos Fass Prex"
   },
   "/Lotus/StoreItems/Types/Items/ShipDecos/TarotCardTennoConF": {
     "value": "Deimos Jugulus Prex"
@@ -142,6 +151,9 @@
   },
   "/Lotus/StoreItems/Types/StoreItems/AvatarImages/Seasonal/AvatarImageCNY2025SnakeGlyphA": {
     "value": "Giving Snake Glyph"
+  },
+  "/Lotus/StoreItems/Types/StoreItems/AvatarImages/TwinSnakesGlyph": {
+    "value": "Vome-Fass Glyph"
   },
   "/Lotus/StoreItems/Upgrades/CosmeticEnhancers/Peculiars/EvilSpiritMod": {
     "value": "Peculiar Audience"
@@ -215,6 +227,9 @@
   "/Lotus/StoreItems/Upgrades/Skins/Clan/Dragon2024BadgeItem": {
     "value": "Lunar Renewal Dragon Emblem"
   },
+  "/Lotus/StoreItems/Upgrades/Skins/Effects/BaroEphemeraB": {
+    "value": "Ki'Teer Reverence Ephemera"
+  },
   "/Lotus/StoreItems/Upgrades/Skins/Effects/FootstepsMaple": {
     "value": "Fae Path Ephemera"
   },
@@ -226,6 +241,12 @@
   },
   "/Lotus/StoreItems/Upgrades/Skins/Liset/LisetSkinVoidTrader": {
     "value": "Liset Prisma Skin"
+  },
+  "/Lotus/StoreItems/Upgrades/Skins/MeleeDangles/MoonWarfanSugatraMeleeDangle": {
+    "value": "Renayla Sugatra"
+  },
+  "/Lotus/StoreItems/Upgrades/Skins/Operator/Accessories/AshLevarianTiara": {
+    "value": "Scoria Diadem"
   },
   "/Lotus/StoreItems/Upgrades/Skins/Operator/Accessories/BaroHorn": {
     "value": "Ki'teer Cornu Diadem"
@@ -281,6 +302,9 @@
   "/Lotus/StoreItems/Upgrades/Skins/Weapons/Rapier/CrpRapierSkin": {
     "value": "Rapier Tributaker Skin"
   },
+  "/Lotus/StoreItems/Weapons/Corpus/Melee/CrpTonfa/CrpPrismaTonfa": {
+    "value": "Prisma Ohma"
+  },
   "/Lotus/StoreItems/Weapons/Grineer/Melee/GrineerMachetteAndCleaver/WraithMacheteWeapon": {
     "value": "Machete Wraith"
   },
@@ -293,12 +317,17 @@
   "/Lotus/StoreItems/Weapons/Tenno/Archwing/Primary/ArchwingHeavyPistols/Prisma/PrismaArchHeavyPistols": {
     "value": "Prisma Dual Decurions"
   },
+  "/Lotus/Types/Challenges/Calendar1999/CalendarDestroyPropsEasy": {
+    "value": "Starve the beast",
+    "desc": "Destroy 75 Containers"
+  },
   "/Lotus/Types/Challenges/Calendar1999/CalendarDestroyPropsMedium": {
     "value": "Starve the beast",
     "desc": "Destroy 150 Containers"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillEnemiesMedium": {
-    "value": "Kill 500 Enemies"
+    "value": "Even the odds",
+    "desc": "Kill 500 Enemies"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillEnemiesWithAbilitiesHard": {
     "value": "Demonstration of power",
@@ -320,6 +349,10 @@
     "value": "Punish Scaldra",
     "desc": "Kill 250 Scaldra Troops"
   },
+  "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesHard": {
+    "value": "Punish Scaldra",
+    "desc": "Kill 500 Scaldra Troops"
+  },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesMedium": {
     "value": "Punish Scaldra",
     "desc": "Kill 350 Scaldra Troops"
@@ -332,12 +365,21 @@
     "value": "Shock and Awe",
     "desc": "Kill 250 Scaldra Troops with Abilities"
   },
+  "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesWithAbilitiesMedium": {
+    "value": "Shock and Awe",
+    "desc": "Kill 150 Scaldra Troops with Abilities"
+  },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesWithMeleeEasy": {
-    "value": "Kill 75 Scaldra Troops with Melee Weapons"
+    "value": "Make it personal",
+    "desc": "Kill 75 Scaldra Troops with Melee Weapons"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillScaldraEnemiesWithMeleeMedium": {
     "value": "Make it personal",
     "desc": "Kill 300 Scaldra Troops with Melee Weapons"
+  },
+  "/Lotus/Types/Challenges/Calendar1999/CalendarKillTankHard": {
+    "value": "Tankless Work",
+    "desc": "Destroy 1 Tanks"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillTechrotEnemiesEasy": {
     "value": "Purge the infection",
@@ -352,7 +394,8 @@
     "desc": "Kill 500 Techrot"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillTechrotEnemiesWithAbilitiesMedium": {
-    "value": "Kill 200 Techrot with Abilities"
+    "values": "Null and Void",
+    "desc": "Kill 200 Techrot with Abilities"
   },
   "/Lotus/Types/Challenges/Calendar1999/CalendarKillTechrotEnemiesWithMeleeMedium": {
     "value": "Electronic waste Disposal",
@@ -438,6 +481,10 @@
     "value": "Thick Skin",
     "desc": "Gain +250 Armor."
   },
+  "/Lotus/Upgrades/Calendar/AttackAndMovementSpeedOnCritMelee": {
+    "value": "Hit'N'Split",
+    "desc": "Critical melee hits have a chance to increase attack and movement speed by 5% for 10sec."
+  },
   "/Lotus/Upgrades/Calendar/CompanionDamage": {
     "value": "Got Your Back",
     "desc": "Specters and companions gain +250% damage."
@@ -445,6 +492,10 @@
   "/Lotus/Upgrades/Calendar/CompanionsBuffNearbyPlayer": {
     "value": "More the Merrier",
     "desc": "Non-Tenno Allies within 20m all gain +5% Melee Attack Speed and +20% Fire Rate for each one in range."
+  },
+  "/Lotus/Upgrades/Calendar/ElectricStatusDamageAndChance": {
+    "value": "Bottled Lightning",
+    "desc": "Add 25% Status Damage and Electricity Status Chance to all weapons."
   },
   "/Lotus/Upgrades/Calendar/EnergyOrbToAbilityRange": {
     "value": "Broadened Horizons",
@@ -490,9 +541,17 @@
     "value": "Targeted Medicine",
     "desc": "Shoot Health Orbs to pick them up. Health orbs now have 25% chance to duplicate when picked up."
   },
+  "/Lotus/Upgrades/Calendar/OvershieldCap": {
+    "value": "Harden Up",
+    "desc": "Increases Overshield cap by 50%. Kills grant 50 shields."
+  },
   "/Lotus/Upgrades/Calendar/PowerStrengthAndEfficiencyPerEnergySpent": {
     "value": "Overpower",
     "desc": "Casting abilities increases ability strength by 2% and efficiency by -1% per unit of energy used by ability, for 5s."
+  },
+  "/Lotus/Upgrades/Calendar/PunchToPrimary": {
+    "value": "Punchcard",
+    "desc": "Add +1.5m punch through to primary weapons."
   },
   "/Lotus/Upgrades/Calendar/RadiationProcOnTakeDamage": {
     "value": "Psionic Feedback",


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
New Baro items:
- Erra Noggle
- Cutter Fighter Decoration
- Deimos Fass Prex
- Vome-Fass glyph
- Ki'Teer Reverence Ephemera
- Renayla Sugatra
- Scoria Diadem
- Prisma Ohma

Fix Calendar Challenges:
- Add value "Even the odds"
- Add value "Make it personal"
- Add value "Null and Void"

New Calendar Challenges:
- "Starve the beast" easy
- "Punish the Scaldra" hard
- "Shock and Awe" medium
- "Tankless Work" hard

New Calendar Overrides:
- Hit'N'Split
- Bottled Lightning
- Harden Up
- Punchcard

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded the in-game store with new items such as ship decorations, avatar images, and engaging upgrades.
  - Introduced upgrades that enhance combat performance, including boosts to attack, movement, status effects, and defensive capabilities.
  - Added and refined challenge objectives with updated descriptions, offering players more varied and strategic gameplay options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->