### PR TITLE
fix: updated modifiers and risk variables for DA

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -19040,6 +19040,10 @@
   "ArbitersSyndicate": {
     "value": "Arbiters of Hexis"
   },
+  "Armorless": {
+    "value": "Fractured Armor",
+    "desc": "Casting an ability reduces armor by 10% for 10s."
+  },
   "AssassinsSyndicate": {
     "value": "Assassins"
   },
@@ -19049,9 +19053,17 @@
   "CetusSyndicate": {
     "value": "Ostrons"
   },
+  "ContactDamage": {
+    "value": "Secondary Wounds",
+    "desc": "Gain 1 Puncture Status Effect every time you take damage."
+  },
   "Deflectors": {
     "value": "Fortified Foes",
     "desc": "Guardian Eximus units may be encountered, including Guardian Eximus Necramechs."
+  },
+  "EMPBlackHole": {
+    "value": "Alluring Arcocanids",
+    "desc": "As Rogue Arcocanids charge attacks, they pull Warframes towards them."
   },
   "EntratiSyndicate": {
     "value": "Entrati"
@@ -19059,13 +19071,21 @@
   "EventSyndicate": {
     "value": "Operations Syndicate"
   },
+  "ExplosiveCrawlers": {
+    "value": "Explosive Potential",
+    "desc": "Rupturing Fragments replace Shuffling Fragments."
+  },
   "FragileNodes": {
     "value": "Unified Purpose",
-    "desc": "Enemies can target and destry Conduits."
+    "desc": "Enemies can target and destroy Conduits."
   },
   "Framecurse": {
     "value": "Framecurse syndrome",
     "desc": "Activating an Ability inflicts 50 damage upon you."
+  },
+  "Gearless": {
+    "value": "Gear Embargo",
+    "desc": "Gear cannot be used."
   },
   "GrowingIncursion": {
     "value": "Fissure Cascade",


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Deep Archimedea seems to be currently in sync with the in-game challenges so I managed to add some that showed up for this week

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**
