### PR TITLE
fix: add mission deviations and variables for Temporal Archimedea

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -19040,6 +19040,10 @@
   "ArbitersSyndicate": {
     "value": "Arbiters of Hexis"
   },
+  "ArcadeAutomata": {
+    "value": "Arcade Automate",
+    "desc": "Enemy guns launch large, slow moving orbs instead of their usual ordnance."
+  },
   "Armorless": {
     "value": "Fractured Armor",
     "desc": "Casting an ability reduces armor by 10% for 10s."
@@ -19053,6 +19057,10 @@
   "CetusSyndicate": {
     "value": "Ostrons"
   },
+  "ChemicalNoise": {
+    "value": "Noise Suppression",
+    "desc": "Drones fly above Flare, spraying them with Efervon gas."
+  },
   "ContactDamage": {
     "value": "Secondary Wounds",
     "desc": "Gain 1 Puncture Status Effect every time you take damage."
@@ -19061,12 +19069,20 @@
     "value": "Fortified Foes",
     "desc": "Guardian Eximus units may be encountered, including Guardian Eximus Necramechs."
   },
+  "DullBlades": {
+    "value": "Dull Blades",
+    "desc": "-50% melee combo chance"
+  },
   "EMPBlackHole": {
     "value": "Alluring Arcocanids",
     "desc": "As Rogue Arcocanids charge attacks, they pull Warframes towards them."
   },
   "EntratiSyndicate": {
     "value": "Entrati"
+  },
+  "EscalateImmediately": {
+    "value": "Cache Crash",
+    "desc": "Consequences of opening a Supply Cache are active from the start and will intensify once it is opened. Failure to open a Supply Cache doubles the kill count required to finish the mission."
   },
   "EventSyndicate": {
     "value": "Operations Syndicate"
@@ -19091,9 +19107,21 @@
     "value": "Fissure Cascade",
     "desc": "Fissures rip into the mission, causing the Enemy Level to go up by 1 every 10s. Destroy them to stop the level from increasing further."
   },
+  "HeavyWarfare": {
+    "value": "Heavy Warfare",
+    "desc": "Enemies take 95% less damage from non-heavy weapons. Enemies will drop heavy ammo packs and heavy weapon recall time reduced to 5s."
+  },
+  "HostileOvergrowth": {
+    "value": "It's Alive",
+    "desc": "Within the underground, hostile overgrowths will attack if players stops moving."
+  },
   "InfiniteTide": {
     "value": "Relentless Tide",
     "desc": "The Fragmented Tide never stops attacking."
+  },
+  "JadeSpring": {
+    "value": "Jade Spirits",
+    "desc": "Jade Wisps haunt the region. If approached, they chase down the player responsible and transform into Jade Light beams."
   },
   "KahlSyndicate": {
     "value": "Kahl's Garrison"
@@ -19106,6 +19134,10 @@
     "value": "Glyph Inflation",
     "desc": "The security system requires twice as many Vosphene Glyphs to activate."
   },
+  "MiasmiteHive": {
+    "value": "Miasmite Swarm",
+    "desc": "Techrot Miasmites swarm out of the shadows throught the mission."
+  },
   "NecraloidSyndicate": {
     "value": "Necraloid"
   },
@@ -19115,6 +19147,10 @@
   "OperatorLockout": {
     "value": "Transference Distortion",
     "desc": "Transference into Operator and Drifter is blocked."
+  },
+  "OverSensitive": {
+    "value": "Hypersensitive",
+    "desc": "Duration of negative Status Effects is tripled"
   },
   "PerrinSyndicate": {
     "value": "Perrin Sequence"
@@ -19173,6 +19209,10 @@
   },
   "SteelMeridianSyndicate": {
     "value": "Steel Meridian"
+  },
+  "TechrotConjunction": {
+    "value": "Pile-On",
+    "desc": "Techrot enemies attempt to melee attack Hell-Scrubbers, bursting on contact and increasing scrubber contamination by 33%."
   },
   "TimeDilation": {
     "value": "Abbreviated Abilities",


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Add add mission deviations and variables for Temporal Archimedea. Looks like they're gonna be shared so most of langs alreayd exist

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced several gameplay adjustments that impact combat and mission dynamics, including:
    - Revised enemy attack patterns with heavier, slower projectiles.
    - New environmental effects such as hazardous gas releases and reactive underground growths.
    - Adjustments to melee combat with reduced combo chances and extended negative status durations.
    - Updated mission triggers and consequences tied to supply interactions.
    - Added enemy behaviors featuring chasing entities, swarming attacks, and increased contamination effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->