### PR TITLE
feat: add `Operation: Eight Claw` strings

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -5,6 +5,15 @@
   "/Lotus/Language/G1Quests/HeatFissuresEventScore": {
     "value": "Thermia Fractures Sealed"
   },
+  "/Lotus/Language/Isleweaver/DuviriMurmurEventDescription": {
+    "value": "Recover stolen Dominus Aureus to take down Neci Rusalka and return Dominus Thrax to his throne! Obtain them from Operation: Eight Claw spirals in Duviri.\n\nVisit Thrax in the Dormizone to exchange Dominus Aureus for rewards. Invictus Signas will be unlocked as the community returns stolen Aureus to Thrax."
+  },
+  "/Lotus/Language/Isleweaver/DuviriMurmurEventScore": {
+    "value": "Dominus Aureus Collection Progress:"
+  },
+  "/Lotus/Language/Isleweaver/DuviriMurmurEventTitle": {
+    "value": "Operation: Eight Claw"
+  },
   "/Lotus/Language/JadeShadows/JadeShadowsEventName": {
     "value": "Operation: Belly of the Beast"
   },


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
adds string value for 

/Lotus/Language/Isleweaver/DuviriMurmurEventScore
/Lotus/Language/Isleweaver/DuviriMurmurEventDescription
/Lotus/Language/Isleweaver/DuviriMurmurEventTitle

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new language support for "Operation: Eight Claw," including event title, description with gameplay instructions, and a score label to track collection progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->