### PR TITLE
feat: add some time utilities for DE reset timestamps

### DIFF
--- a/test/utilities/timedate.spec.ts
+++ b/test/utilities/timedate.spec.ts
@@ -1,6 +1,6 @@
 import { should } from 'chai';
 
-import { timeDeltaToString, parseDate, WorldStateDate } from '../../tools/timeDate';
+import { timeDeltaToString, parseDate, ContentTimestamp } from '../../tools/timeDate';
 
 should();
 
@@ -26,9 +26,9 @@ describe('timeDateUtils', () => {
   });
   describe('parseDate()', () => {
     it('should parse even if date provided is undefined', () => {
-      (() => parseDate(undefined as unknown as WorldStateDate)).should.not.throw();
-      (() => parseDate(0 as unknown as WorldStateDate)).should.not.throw();
-      (() => parseDate(2340985790347890 as unknown as WorldStateDate)).should.not.throw();
+      (() => parseDate(undefined as unknown as ContentTimestamp)).should.not.throw();
+      (() => parseDate(0 as unknown as ContentTimestamp)).should.not.throw();
+      (() => parseDate(2340985790347890 as unknown as ContentTimestamp)).should.not.throw();
     });
   });
 });

--- a/tools/timeDate.ts
+++ b/tools/timeDate.ts
@@ -79,28 +79,35 @@ export const parseDate = (d?: ContentTimestamp): Date => {
 /**
  * Get a weekly reset timestamp
  */
-export const weeklyReset = (): Date => {
+export const weeklyReset = (): { activation: Date; expiry: Date } => {
   const now = new Date();
   const currentDay = now.getUTCDay();
   const daysUntilNextMonday = currentDay === 0 ? 1 : 8 - currentDay;
 
-  const nextWeekStart = new Date(now.getTime());
-  nextWeekStart.setUTCDate(now.getUTCDate() + daysUntilNextMonday);
-  nextWeekStart.setUTCHours(0, 0, 0, 0);
+  const expiry = new Date(now.getTime());
+  expiry.setUTCDate(now.getUTCDate() + daysUntilNextMonday);
+  expiry.setUTCHours(0, 0, 0, 0);
 
-  return nextWeekStart;
+  const activation = new Date(expiry.getTime());
+  activation.setUTCDate(expiry.getUTCDate() - 7);
+
+  return { activation, expiry };
 };
 
 /**
  * Get a daily reset timestamp
  */
-export const dailyReset = (): Date => {
+export const dailyReset = (): { activation: Date; expiry: Date } => {
   const now = new Date();
-  const nextDayStart = new Date(now.getTime());
-  nextDayStart.setUTCDate(now.getUTCDate() + 1);
-  nextDayStart.setUTCHours(0, 0, 0, 0);
 
-  return nextDayStart;
+  const activation = new Date(now.getTime());
+  activation.setUTCHours(0, 0, 0, 0);
+
+  const expiry = new Date(now.getTime());
+  expiry.setUTCDate(now.getUTCDate() + 1);
+  expiry.setUTCHours(0, 0, 0, 0);
+
+  return {activation, expiry};
 };
 
 /**

--- a/tools/timeDate.ts
+++ b/tools/timeDate.ts
@@ -1,4 +1,4 @@
-const epochZero: WorldStateDate = {
+const epochZero: ContentTimestamp = {
   $date: {
     $numberLong: 0,
   },
@@ -61,7 +61,7 @@ export const toNow = (d: Date, now: () => number = Date.now): number => {
   return now() - d.getTime();
 };
 
-export interface WorldStateDate {
+export interface ContentTimestamp {
   $date?: { $numberLong: number };
 }
 
@@ -70,10 +70,37 @@ export interface WorldStateDate {
  * @param {Object} d The worldState date object
  * @returns {Date} parsed date from DE date format
  */
-export const parseDate = (d?: WorldStateDate): Date => {
+export const parseDate = (d?: ContentTimestamp): Date => {
   const safeD = d || epochZero;
   const dt = safeD.$date || epochZero.$date;
-  return new Date(safeD.$date ? Number(dt!.$numberLong) : 1000 * (d as {sec: number}).sec);
+  return new Date(safeD.$date ? Number(dt!.$numberLong) : 1000 * (d as { sec: number }).sec);
+};
+
+/**
+ * Get a weekly reset timestamp
+ */
+export const weeklyReset = (): Date => {
+  const now = new Date();
+  const currentDay = now.getUTCDay();
+  const daysUntilNextMonday = currentDay === 0 ? 1 : 8 - currentDay;
+
+  const nextWeekStart = new Date(now.getTime());
+  nextWeekStart.setUTCDate(now.getUTCDate() + daysUntilNextMonday);
+  nextWeekStart.setUTCHours(0, 0, 0, 0);
+
+  return nextWeekStart;
+};
+
+/**
+ * Get a daily reset timestamp
+ */
+export const dailyReset = (): Date => {
+  const now = new Date();
+  const nextDayStart = new Date(now.getTime());
+  nextDayStart.setUTCDate(now.getUTCDate() + 1);
+  nextDayStart.setUTCHours(0, 0, 0, 0);
+
+  return nextDayStart;
 };
 
 /**
@@ -90,4 +117,6 @@ export default {
   fromNow,
   toNow,
   parseDate,
+  dailyReset,
+  weeklyReset,
 };


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Add some time utilities that align with how DE does daily and weekly resets, oh and renamed `WorldStateDate` to `ContentTimestamp`

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added functions to calculate the next daily and weekly reset times.

* **Refactor**
  * Renamed a date-related type for improved clarity across the app.

* **Tests**
  * Updated tests to use the new date type naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->