### PR TITLE
fix: add missing langs for `Dagath` alerts

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -242,6 +242,12 @@
   "/Lotus/StoreItems/Types/Recipes/Components/WeaponUtilityUnlockerBlueprint": {
     "value": "Exilus Weapon Adapter Blueprint"
   },
+  "/Lotus/StoreItems/Types/Recipes/WarframeRecipes/DagathChassisComponent": {
+    "value": "Dagath Chassis"
+  },
+  "/Lotus/StoreItems/Types/Recipes/WarframeRecipes/DagathHelmetComponent": {
+    "value": "Dagath Neuroptics"
+  },
   "/Lotus/StoreItems/Types/Restoratives/Consumable/AssassinBait": {
     "value": "Stalker Beacon"
   },


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Add langs for `Dagath` alert drops

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**
