### PR TITLE
Add archimedea deviation translations

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -19303,10 +19303,6 @@
     "value": "Alchemical Invulnerability",
     "desc": "10% of enemies are equipped with an impervious Elemental Barrier that can only be destroyed by an Amphor of the corresponding element."
   },
-  "AntiGuard": {
-    "value": "Anti Guard",
-    "desc": "Guard units are disabled. Enemies deal increased damage."
-  },
   "AntiMaterialWeapons": {
     "value": "Commanding Culverins",
     "desc": "Rogue Culverins equip weapons that deal 5x Damage to Overguard and Necramechs."


### PR DESCRIPTION
- Add AlchemicalShields, DoubleTrouble, EnergyStarved, Exhaustion
- Add FactionSwarm_Techrot, InfectedTechrot, TankSuperToxic, UnpoweredCapsules
- Fix TechrotConjunction description (33% -> 25% to match official table)
- All entries sorted alphabetically
- Data taken from the wiki

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No code changes]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Enhancement]**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seven new challenge modifiers: Alchemical Invulnerability, Double Trouble, Energy Exhaustion, Techrot Speed Run, Corrupted Flesh, Parasitic Towers, and Toxic Tank, bringing fresh difficulty options to gameplay.

* **Updates**
  * Improved clarity of existing challenge modifier descriptions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->