### PR TITLE
feat: add missing Archimedea translations and fix typo

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -19349,6 +19349,10 @@
     "value": "Alchemical Invulnerability",
     "desc": "10% of enemies are equipped with an impervious Elemental Barrier that can only be destroyed by an Amphor of the corresponding element."
   },
+  "AntiGuard": {
+    "value": "Dropped Guard",
+    "desc": "Warframe and ally Overguard gain reduced by 75%."
+  },
   "AntiMaterialWeapons": {
     "value": "Commanding Culverins",
     "desc": "Rogue Culverins equip weapons that deal 5x Damage to Overguard and Necramechs."
@@ -19372,7 +19376,7 @@
     "value": "Assassins"
   },
   "BalloonFest": {
-    "value": "Ballonfest",
+    "value": "Balloonfest",
     "desc": "Scaldra Harbingers are more numerous and attack and move more quickly."
   },
   "CephalonSudaSyndicate": {
@@ -19680,6 +19684,10 @@
   "Voidburst": {
     "value": "Postmortal Surges",
     "desc": "Slain enemies burts with Void energy."
+  },
+  "VolatileGrenades": {
+    "value": "Hazardous Goods",
+    "desc": "Amphors deal elemental damage while carried."
   },
   "VoxSyndicate": {
     "value": "Vox Solaris"


### PR DESCRIPTION
- Add AntiGuard (Dropped Guard)
- Add VolatileGrenades (Hazardous Goods)
- Fix BalloonFest value typo: Ballonfest → Balloonfest

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Docs]**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a spelling error in an existing game modifier entry.

* **New Features**
  * Added "Dropped Guard" modifier: reduces Warframe and ally Overguard effectiveness by 75%.
  * Added "Hazardous Goods" modifier: enables Amphors to deal elemental damage while being carried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->