### PR TITLE
feat: add missing Archimedea and Nightwave translations

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -14095,6 +14095,10 @@
     "desc": "Kill a Silver Grove Specter",
     "value": "Grove Guardian"
   },
+  "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardkilltank": {
+    "desc": "Defeat an H-09 Efervon Tank",
+    "value": "Tanked"
+  },
   "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardkillthumper": {
     "desc": "Kill a Tusk Thumper Doma in the Plains of Eidolon",
     "value": "Walk Without Rhythm"


### PR DESCRIPTION
## Summary
- Add `DoubleTroubleLegacyte` → **Mitosis** ("Two Legacytes spawn each round and twice as many captures are needed for success.")
- Add `TankReinforcements` → **Reinforcements** ("Reinforcements will arrive during the fight.")
- Add `seasonweeklyhardkilltank` → **Tanked** ("Defeat an H-09 Efervon Tank")

All three keys currently return `[PH]` placeholder descriptions in the parsed worldstate.

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **N/A** – this PR only adds translation data
- Have I run the linter? **Yes**
- Is it a bug fix, feature request, or enhancement? **Bug Fix**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new weekly hard season challenge to defeat the H-09 Efervon Tank
  * Added new enemy encounter type: DoubleTroubleLegacyte with increased spawn rates and capture requirements
  * Added new combat mechanic: Reinforcements arrive during tank fights

<!-- end of auto-generated comment: release notes by coderabbit.ai -->