### PR TITLE
feat: add missing Nightwave EliteBeastSlayer translation

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -14027,6 +14027,10 @@
     "desc": "Complete 5 Steel Path Missions.",
     "value": "The Path Less Travelled"
   },
+  "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardelitebeastslayer": {
+    "desc": "Defeat the Orowyrm in Steel Path",
+    "value": "Elite Beast Slayer"
+  },
   "/lotus/types/challenges/seasons/weeklyhard/seasonweeklyhardelitesanctuaryonslaught": {
     "desc": "Complete 8 Zones of Elite Sanctuary Onslaught",
     "value": "Elite Test Subject"


### PR DESCRIPTION
### What did you fix?

Add missing Nightwave challenge translation for `SeasonWeeklyHardEliteBeastSlayer` (Elite Beast Slayer). The challenge currently shows `[PH] Season Weekly Hard Elite Beast Slayer Desc` as its description and uses the camelCase-split fallback as its title because the key is missing from `languages.json`.

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes** — manual translation entry based on the [Warframe Wiki](https://wiki.warframe.com/w/Nightwave)
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No** — single commit, data-only change
- Have I run the linter? **Yes**
- Is it a bug fix, feature request, or enhancement? **Bug Fix**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Elite Beast Slayer" seasonal challenge for defeating the Orowyrm in Steel Path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->