### PR TITLE
feat: missing Nightwave challenge translation

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -13539,6 +13539,10 @@
     "desc": "Hijack a Crewship from the enemy",
     "value": "Confiscated"
   },
+  "/lotus/types/challenges/seasons/weekly/seasonweeklyhorsingaround": {
+    "desc": "Fly your Kaithe for 1000 meters",
+    "value": "Horsing Around"
+  },
   "/lotus/types/challenges/seasons/weekly/seasonweeklyisolationbounties": {
     "desc": "Complete an Isolation Vault Bounty Mission on Deimos",
     "value": "Vault Raider"


### PR DESCRIPTION
## Summary
- Add missing translation for `SeasonWeeklyHorsingAround` Nightwave challenge
  - **value**: "Horsing Around"
  - **desc**: "Fly your Kaithe for 1000 meters"

Currently the API returns `[PH] Season Weekly Horsing Around Desc` as the description and uses the camelCase-split fallback name "Season Weekly Horsing Around" instead of the correct display name.

## Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes — manual translation entry based on the Warframe Wiki**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No — single commit, data-only change**
- Have I run the linter? **Yes**
- Is it a bug fix, feature request, or enhancement? **Bug Fix**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new seasonal weekly challenge: "Horsing Around" - Fly your Kaithe for 1000 meters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->