### PR TITLE
feat: add missing Nightwave challenge translation (SeasonWeeklyHardCompleteConquest)

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -648,6 +648,10 @@
     "value": "Electronic waste Disposal",
     "desc": "Kill 200 Techrot with Melee Weapons"
   },
+  "/Lotus/Types/Challenges/Seasons/WeeklyHard/SeasonWeeklyHardCompleteConquest": {
+    "value": "Voluntary Specimen",
+    "desc": "Complete a run of Deep Archimedea or Temporal Archimedea"
+  },
   "/Lotus/Types/Gameplay/JadeShadows/Resources/AscensionEventResourceItem": {
     "value": "Volatile Motes"
   },


### PR DESCRIPTION
Adds the missing translation for the Nightwave elite weekly challenge `SeasonWeeklyHardCompleteConquest`.

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Voluntary Specimen" seasonal challenge - complete a run of Deep Archimedea or Temporal Archimedea

<!-- end of auto-generated comment: release notes by coderabbit.ai -->