### PR TITLE
feat: add missing event translations and SolNode239

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -1627,6 +1627,9 @@
   "/lotus/language/events/amalgameventtooltip": {
     "value": "Operation: Hostile Mergers"
   },
+  "/lotus/language/events/anniversary2024challengemode": {
+    "value": "Gifts Of The Lotus – Elite"
+  },
   "/lotus/language/events/halloweennaberusdesc": {
     "value": "Visit Daughter for Naberus Treats"
   },
@@ -1845,6 +1848,9 @@
   },
   "/lotus/language/messages/orbheisteventrewarddinboxmessagetitle": {
     "value": "Vallis Fractures: Real Progress"
+  },
+  "/lotus/language/shadowgrapher/shadowgraphereventname": {
+    "value": "Operation: Atramentum"
   },
   "/lotus/language/sigils/kelaeventsigilname": {
     "desc": "A sigil commemorating the liberation of defectors from the Grineer.",

--- a/data/solNodes.json
+++ b/data/solNodes.json
@@ -1184,6 +1184,11 @@
     "enemy": "Duviri",
     "type": "Free Roam"
   },
+  "SolNode239": {
+    "value": "Vesper Relay (Venus)",
+    "enemy": "Corpus",
+    "type": "Relay"
+  },
   "ZarimanHub": {
     "value": "Chrysalith (Zariman)",
     "enemy": "Tenno",


### PR DESCRIPTION
- Add Anniversary2024ChallengeMode (Gifts Of The Lotus – Elite)
- Add ShadowgrapherEventName (Operation: Atramentum)
- Add SolNode239 (Vesper Relay, Venus - Shadowgrapher event node)

### What did you fix?
Added missing translations for active events and a missing sol node entry:
- `/lotus/language/events/anniversary2024challengemode` — 13th Anniversary Elite tactical alert was showing as "Anniversary2024 Challenge Mode" instead of "Gifts Of The Lotus – Elite"
- `/lotus/language/shadowgrapher/shadowgraphereventname` — Operation: Atramentum event was showing as "Shadowgrapher Event Name" instead of "Operation: Atramentum"
- `SolNode239` — Vesper Relay (Venus) node used by the Shadowgrapher event was missing from solNodes.json, causing it to display as raw "SolNode239"

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes** — manual data entry for event translations and sol node based on live worldstate API data and official Warframe news
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No** — data-only changes
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "Gifts Of The Lotus – Elite" challenge mode for the anniversary event with increased difficulty.
  * Added "Operation: Atramentum" event for player engagement.
  * Added Vesper Relay, a new Corpus-controlled relay station on Venus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->