### PR TITLE
feat(Complete Race): add missing Nightwave challenge translation

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -648,6 +648,10 @@
     "value": "Electronic waste Disposal",
     "desc": "Kill 200 Techrot with Melee Weapons"
   },
+  "/Lotus/Types/Challenges/Seasons/Weekly/SeasonWeeklyCompleteRace": {
+    "value": "Ollie Oop!",
+    "desc": "Play Ollie's Crash Course and complete a race."
+  },
   "/Lotus/Types/Challenges/Seasons/Weekly/SeasonWeeklyKillEnemiesWithHeadshots": {
     "value": "Not a Warning Shot",
     "desc": "Kill 100 enemies with headshots"


### PR DESCRIPTION
Add missing translation for the Nightwave weekly challenge `SeasonWeeklyCompleteRace`.

**Before:** Title shows as "Season Weekly Complete Race" with `[PH] Season Weekly Complete Race Desc` placeholder.

**After:**
- **Name:** Ollie Oop!
- **Description:** Play Ollie's Crash Course and complete a race.

Key: `/Lotus/Types/Challenges/Seasons/Weekly/SeasonWeeklyCompleteRace`

Source: [Nightwave Acts (wiki)](https://wiki.warframe.com/w/Nightwave/Acts)

## Considerations

- **Does this contain a new dependency?** No
- **Does this introduce opinionated data formatting or manual data entry?** Yes — manual data entry for event translations and sol node based on live worldstate API data and official Warframe news
- **Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr?** No — data-only changes
- **Have I run the linter?** Yes
- **Is it a bug fix, feature request, or enhancement?** Bug Fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New weekly challenge "Ollie Oop!" is now available. Complete Ollie's Crash Course and finish a race to progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->