### PR TITLE
feat: add missing Archimedea and Nightwave translations

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -656,6 +656,10 @@
     "value": "Not a Warning Shot",
     "desc": "Kill 100 enemies with headshots"
   },
+  "/Lotus/Types/Challenges/Seasons/WeeklyHard/SeasonWeeklyHardCeremonialEvolution": {
+    "value": "Ceremonial Evolution",
+    "desc": "Evolve any Incarnon weapon in-mission 5 times"
+  },
   "/Lotus/Types/Challenges/Seasons/WeeklyHard/SeasonWeeklyHardCompleteConquest": {
     "value": "Voluntary Specimen",
     "desc": "Complete a run of Deep Archimedea or Temporal Archimedea"
@@ -19506,6 +19510,10 @@
   "ExplosiveEnergy": {
     "value": "Miasmite Mash",
     "desc": "Enemies drop Miasmites upon death that immediately rush Flare."
+  },
+  "ExplosiveSummer": {
+    "value": "Excessive Explosives",
+    "desc": "All supply crates are replaced with explosive barrels."
   },
   "FactionSwarm_Scaldra": {
     "value": "Scaldra Speed Run",


### PR DESCRIPTION
Add missing translations for the `ExplosiveSummer` Archimedea risk and the `SeasonWeeklyHardCeremonialEvolution` Nightwave elite weekly challenge.

## Considerations

- **Does this contain a new dependency?** No
- **Does this introduce opinionated data formatting or manual data entry?** Yes — manual data entry for Archimedea risk and Nightwave challenge strings that are missing from the game's localization export
- **Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr?** No — data-only changes
- **Have I run the linter?** Yes
- **Is it a bug fix, feature request, or enhancement?** Bug Fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Ceremonial Evolution" challenge: evolve Incarnon weapons in-mission 5 times.
  * Added "Excessive Explosives" modifier: replaces supply crates with explosive barrels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->