### PR TITLE
feat: add missing Nightwave challenge translation

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -656,6 +656,10 @@
     "value": "Not a Warning Shot",
     "desc": "Kill 100 enemies with headshots"
   },
+  "/Lotus/Types/Challenges/Seasons/Weekly/SeasonWeeklyOpenLockers": {
+    "value": "Kleptomaniac",
+    "desc": "Open 30 Lockers"
+  },
   "/Lotus/Types/Challenges/Seasons/WeeklyHard/SeasonWeeklyHardCeremonialEvolution": {
     "value": "Ceremonial Evolution",
     "desc": "Evolve any Incarnon weapon in-mission 5 times"


### PR DESCRIPTION
Add missing translation for the `SeasonWeeklyOpenLockers` Nightwave weekly challenge.

## Considerations

- **Does this contain a new dependency?** No
- **Does this introduce opinionated data formatting or manual data entry?** Yes — manual data entry for Nightwave challenge strings that are missing from the game's localization export
- **Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr?** No — data-only changes
- **Have I run the linter?** Yes
- **Is it a bug fix, feature request, or enhancement?** Bug Fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new weekly challenge: "Kleptomaniac" with the objective to open 30 lockers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->