### PR TITLE
Add missing Infested Salvage mission type

### DIFF
--- a/data/missionTypes.json
+++ b/data/missionTypes.json
@@ -44,6 +44,9 @@
   "MT_MOBILE_DEFENSE": {
     "value": "Mobile Defense"
   },
+  "MT_PURIFY": {
+    "value": "Infested Salvage"
+  },
   "MT_PVP": {
     "value": "Conclave"
   },


### PR DESCRIPTION
Closes #922 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new mission type: **Infested Salvage**.
  * This mission type now appears in the game’s mission list and related displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->